### PR TITLE
Return coordinates by default instead of address. Fixes #11

### DIFF
--- a/location-field.php
+++ b/location-field.php
@@ -393,7 +393,7 @@ class ACF_Location_Field extends acf_Field
 			$value = array( 'coordinates' => $value[1], 'address' => $value[0] );
 		}
 		else {
-			$value = $value[0];
+			$value = $value[1];
 		}
 		
 		// return value


### PR DESCRIPTION
As said in #11, `the_field('location')` should return coordinates and not the address. This is said so in [the user documentation](http://www.advancedcustomfields.com/add-ons/google-maps/).
