### PR TITLE
Update conditional for getting the value

### DIFF
--- a/location-field.php
+++ b/location-field.php
@@ -388,7 +388,7 @@ class ACF_Location_Field extends acf_Field
 		
 		// format value
 		$value = explode('|', $value);
-		if ($field['val'] == 'address') 
+		if ( $field['val'] == 'address' && count( $value ) >=2 )  
 		{
 			$value = array( 'coordinates' => $value[1], 'address' => $value[0] );
 		}


### PR DESCRIPTION
Hello, was getting a notice (with debug turned on) if say a post using this as a ACF metabox didn't have an address or coordinates value (and wasn't a required field). Updating this conditional fixed that and now properly displays nothing if empty or null. Props to @codearachnid for helping me solve this.
